### PR TITLE
Improve dep-check to avoid some errors

### DIFF
--- a/.githooks/dep-check
+++ b/.githooks/dep-check
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-function changed {
+changed() {
   git diff --name-only HEAD@{1} HEAD | grep "^$1" > /dev/null 2>&1
 }
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation
- Change from sh to bash and change function to ()
- Avoid this kind of errors:
```
1 file changed, 1 insertion(+), 1 deletion(-)
./.githooks/dep-check: 3: function: not found
./.githooks/dep-check: 5: Syntax error: "}" unexpected
husky - post-merge hook exited with code 2 (error)
```

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
