### PR TITLE
Add new Future method parallel with accumulation

### DIFF
--- a/.husky/trivy-leaks-scan.sh
+++ b/.husky/trivy-leaks-scan.sh
@@ -11,7 +11,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 check_trivy_installed() {
   if ! command -v trivy >/dev/null 2>&1; then
-    echo "Warning: Trivy is not installed. See: https://trivy.dev/latest/getting-started/installation/"
+    echo "Warning: Trivy is not installed. See: https://trivy.dev/docs/latest/getting-started/installation/"
     echo "If you're sure no secrets were added, you can push with:"
     echo "SKIP_SECRET_SCAN=1 git push"
     echo ""

--- a/src/domain/entities/generic/Future.ts
+++ b/src/domain/entities/generic/Future.ts
@@ -1,3 +1,10 @@
+import {
+    FutureWithAccumulation,
+    ParallelAccumulatedData,
+    ParallelWithAccumulationOptions,
+    SequentialAccumulatedData,
+    SequentialWithAccumulationOptions,
+} from "./FutureWithAccumulation";
 import * as rcpromise from "real-cancellable-promise";
 
 /**
@@ -171,102 +178,16 @@ export class Future<E, D> {
         futures: Array<Future<E, D>>,
         options: SequentialWithAccumulationOptions = {}
     ): Future<never, SequentialAccumulatedData<E, D>> {
-        const { stopOnError = false } = options;
-        const processSequentially = (
-            futures: Array<Future<E, D>>,
-            accumulatedData: D[] = []
-        ): Future<never, SequentialAccumulatedData<E, D>> => {
-            const [firstFuture, ...remainingFutures] = futures;
-
-            if (!firstFuture) {
-                return Future.success({ type: "success", data: accumulatedData });
-            }
-
-            return firstFuture
-                .flatMap(resultData => {
-                    return processSequentially(remainingFutures, [...accumulatedData, resultData]);
-                })
-                .flatMapError((error: E) => {
-                    if (stopOnError) {
-                        const accumulatedDataWithError: SequentialAccumulatedData<E, D> = {
-                            type: "error",
-                            error: error,
-                            data: accumulatedData,
-                        };
-                        return Future.success(accumulatedDataWithError);
-                    } else {
-                        return processSequentially(remainingFutures, accumulatedData);
-                    }
-                });
-        };
-
-        return processSequentially(futures);
+        return FutureWithAccumulation.sequential(futures, options);
     }
 
     static parallelWithAccumulation<E, D>(
         futures: Array<Future<E, D>>,
         options: ParallelWithAccumulationOptions = {}
     ): Future<never, ParallelAccumulatedData<E, D>> {
-        const { concurrency = 10, stopOnError = true } = options;
-
-        const toParallelResult = (future: Future<E, D>): Future<never, ParallelResult<E, D>> => {
-            return future
-                .map<ParallelResult<E, D>>(data => ({ type: "success", data }))
-                .mapError<ParallelResult<E, D>>(error => ({ type: "error", error }))
-                .flatMapError(errorResult =>
-                    Future.success<never, ParallelResult<E, D>>(errorResult)
-                );
-        };
-
-        const processInParallel = (
-            pendingFutures: Array<Future<E, D>>,
-            accumulatedData: D[] = []
-        ): Future<never, ParallelAccumulatedData<E, D>> => {
-            if (pendingFutures.length === 0) {
-                return Future.success({ type: "success", data: accumulatedData });
-            }
-
-            const currentBatch = pendingFutures.slice(0, concurrency);
-            const remainingFutures = pendingFutures.slice(concurrency);
-
-            return Future.parallel(currentBatch.map(toParallelResult), {
-                concurrency: concurrency,
-            }).flatMap(batchResults => {
-                const successfulData = batchResults.flatMap(result =>
-                    result.type === "success" ? [result.data] : []
-                );
-
-                const batchErrors = batchResults.flatMap(result =>
-                    result.type === "error" ? [result.error] : []
-                );
-
-                const nextAccumulatedData = [...accumulatedData, ...successfulData];
-
-                if (batchErrors.length > 0 && stopOnError) {
-                    return Future.success({
-                        type: "error",
-                        errors: batchErrors,
-                        data: nextAccumulatedData,
-                    });
-                }
-
-                return processInParallel(remainingFutures, nextAccumulatedData);
-            });
-        };
-
-        return processInParallel(futures);
+        return FutureWithAccumulation.parallel(futures, options);
     }
 }
-
-export type SequentialAccumulatedData<E, D> =
-    | { type: "success"; data: D[] }
-    | { type: "error"; error: E; data: D[] };
-
-export type ParallelAccumulatedData<E, D> =
-    | { type: "success"; data: D[] }
-    | { type: "error"; errors: E[]; data: D[] };
-
-type ParallelResult<E, D> = { type: "success"; data: D } | { type: "error"; error: E };
 
 export type Cancel = (() => void) | undefined;
 
@@ -276,10 +197,6 @@ interface CaptureAsync<E> {
 }
 
 type ParallelOptions = { concurrency: number };
-
-type SequentialWithAccumulationOptions = { stopOnError?: boolean };
-
-type ParallelWithAccumulationOptions = { concurrency?: number; stopOnError?: boolean };
 
 /* Example of how use Future.fromComputation */
 export function getJSON<U>(url: string): Future<TypeError | SyntaxError, U> {

--- a/src/domain/entities/generic/Future.ts
+++ b/src/domain/entities/generic/Future.ts
@@ -169,7 +169,7 @@ export class Future<E, D> {
 
     static sequentialWithAccumulation<E, D>(
         futures: Array<Future<E, D>>,
-        options: { stopOnError?: boolean } = {}
+        options: SequentialWithAccumulationOptions = {}
     ): Future<never, SequentialAccumulatedData<E, D>> {
         const { stopOnError = false } = options;
         const processSequentially = (
@@ -202,11 +202,71 @@ export class Future<E, D> {
 
         return processSequentially(futures);
     }
+
+    static parallelWithAccumulation<E, D>(
+        futures: Array<Future<E, D>>,
+        options: ParallelWithAccumulationOptions = {}
+    ): Future<never, ParallelAccumulatedData<E, D>> {
+        const { concurrency = 10, stopOnError = true } = options;
+
+        const toParallelResult = (future: Future<E, D>): Future<never, ParallelResult<E, D>> => {
+            return future
+                .map<ParallelResult<E, D>>(data => ({ type: "success", data }))
+                .mapError<ParallelResult<E, D>>(error => ({ type: "error", error }))
+                .flatMapError(errorResult =>
+                    Future.success<never, ParallelResult<E, D>>(errorResult)
+                );
+        };
+
+        const processInParallel = (
+            pendingFutures: Array<Future<E, D>>,
+            accumulatedData: D[] = []
+        ): Future<never, ParallelAccumulatedData<E, D>> => {
+            if (pendingFutures.length === 0) {
+                return Future.success({ type: "success", data: accumulatedData });
+            }
+
+            const currentBatch = pendingFutures.slice(0, concurrency);
+            const remainingFutures = pendingFutures.slice(concurrency);
+
+            return Future.parallel(currentBatch.map(toParallelResult), {
+                concurrency: concurrency,
+            }).flatMap(batchResults => {
+                const successfulData = batchResults.flatMap(result =>
+                    result.type === "success" ? [result.data] : []
+                );
+
+                const batchErrors = batchResults.flatMap(result =>
+                    result.type === "error" ? [result.error] : []
+                );
+
+                const nextAccumulatedData = [...accumulatedData, ...successfulData];
+
+                if (batchErrors.length > 0 && stopOnError) {
+                    return Future.success({
+                        type: "error",
+                        errors: batchErrors,
+                        data: nextAccumulatedData,
+                    });
+                }
+
+                return processInParallel(remainingFutures, nextAccumulatedData);
+            });
+        };
+
+        return processInParallel(futures);
+    }
 }
 
 export type SequentialAccumulatedData<E, D> =
     | { type: "success"; data: D[] }
     | { type: "error"; error: E; data: D[] };
+
+export type ParallelAccumulatedData<E, D> =
+    | { type: "success"; data: D[] }
+    | { type: "error"; errors: E[]; data: D[] };
+
+type ParallelResult<E, D> = { type: "success"; data: D } | { type: "error"; error: E };
 
 export type Cancel = (() => void) | undefined;
 
@@ -216,6 +276,10 @@ interface CaptureAsync<E> {
 }
 
 type ParallelOptions = { concurrency: number };
+
+type SequentialWithAccumulationOptions = { stopOnError?: boolean };
+
+type ParallelWithAccumulationOptions = { concurrency?: number; stopOnError?: boolean };
 
 /* Example of how use Future.fromComputation */
 export function getJSON<U>(url: string): Future<TypeError | SyntaxError, U> {

--- a/src/domain/entities/generic/FutureWithAccumulation.ts
+++ b/src/domain/entities/generic/FutureWithAccumulation.ts
@@ -1,0 +1,110 @@
+import { Future } from "./Future";
+
+export class FutureWithAccumulation {
+    static sequential<E, D>(
+        futures: Array<Future<E, D>>,
+        options: SequentialWithAccumulationOptions = {}
+    ): Future<never, SequentialAccumulatedData<E, D>> {
+        const { stopOnError = false } = options;
+        const processSequentially = (
+            futures: Array<Future<E, D>>,
+            accumulatedData: D[] = []
+        ): Future<never, SequentialAccumulatedData<E, D>> => {
+            const [firstFuture, ...remainingFutures] = futures;
+
+            if (!firstFuture) {
+                return Future.success({ type: "success", data: accumulatedData });
+            }
+
+            return firstFuture
+                .flatMap(resultData => {
+                    return processSequentially(remainingFutures, [...accumulatedData, resultData]);
+                })
+                .flatMapError((error: E) => {
+                    if (stopOnError) {
+                        const accumulatedDataWithError: SequentialAccumulatedData<E, D> = {
+                            type: "error",
+                            error: error,
+                            data: accumulatedData,
+                        };
+                        return Future.success(accumulatedDataWithError);
+                    } else {
+                        return processSequentially(remainingFutures, accumulatedData);
+                    }
+                });
+        };
+
+        return processSequentially(futures);
+    }
+
+    static parallel<E, D>(
+        futures: Array<Future<E, D>>,
+        options: ParallelWithAccumulationOptions = {}
+    ): Future<never, ParallelAccumulatedData<E, D>> {
+        const { concurrency = 10, stopOnError = true } = options;
+
+        const toParallelResult = (future: Future<E, D>): Future<never, ParallelResult<E, D>> => {
+            return future
+                .map<ParallelResult<E, D>>(data => ({ type: "success", data }))
+                .mapError<ParallelResult<E, D>>(error => ({ type: "error", error }))
+                .flatMapError(errorResult =>
+                    Future.success<never, ParallelResult<E, D>>(errorResult)
+                );
+        };
+
+        const processInParallel = (
+            pendingFutures: Array<Future<E, D>>,
+            accumulatedData: D[] = []
+        ): Future<never, ParallelAccumulatedData<E, D>> => {
+            if (pendingFutures.length === 0) {
+                return Future.success({ type: "success", data: accumulatedData });
+            }
+
+            const currentBatch = pendingFutures.slice(0, concurrency);
+            const remainingFutures = pendingFutures.slice(concurrency);
+
+            return Future.parallel(currentBatch.map(toParallelResult), {
+                concurrency: concurrency,
+            }).flatMap(batchResults => {
+                const successfulData = batchResults.flatMap(result =>
+                    result.type === "success" ? [result.data] : []
+                );
+
+                const batchErrors = batchResults.flatMap(result =>
+                    result.type === "error" ? [result.error] : []
+                );
+
+                const nextAccumulatedData = [...accumulatedData, ...successfulData];
+
+                if (batchErrors.length > 0 && stopOnError) {
+                    return Future.success({
+                        type: "error",
+                        errors: batchErrors,
+                        data: nextAccumulatedData,
+                    });
+                }
+
+                return processInParallel(remainingFutures, nextAccumulatedData);
+            });
+        };
+
+        return processInParallel(futures);
+    }
+}
+
+export type ParallelWithAccumulationOptions = {
+    concurrency?: number;
+    stopOnError?: boolean;
+};
+
+export type ParallelAccumulatedData<E, D> =
+    | { type: "success"; data: D[] }
+    | { type: "error"; errors: E[]; data: D[] };
+
+type ParallelResult<E, D> = { type: "success"; data: D } | { type: "error"; error: E };
+
+export type SequentialWithAccumulationOptions = { stopOnError?: boolean };
+
+export type SequentialAccumulatedData<E, D> =
+    | { type: "success"; data: D[] }
+    | { type: "error"; error: E; data: D[] };

--- a/src/domain/entities/generic/__tests__/Future.spec.ts
+++ b/src/domain/entities/generic/__tests__/Future.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test, it, vi, expectTypeOf } from "vitest";
-import { Future, SequentialAccumulatedData } from "$/domain/entities/generic/Future";
+import {
+    Future,
+    ParallelAccumulatedData,
+    SequentialAccumulatedData,
+} from "$/domain/entities/generic/Future";
 
 describe("Basic builders", () => {
     test("Future.success", async () => {
@@ -311,6 +315,54 @@ describe("sequentialWithAccumulation", () => {
             type: "error",
             data: [1, 2],
             error: "error",
+        };
+
+        await expectAsync(values$, { toEqual: expected });
+    });
+});
+
+describe("parallelWithAccumulation", () => {
+    it("if there is no error, it returns an async containing all the accumulated values as an array", async () => {
+        const $futuresArray = [Future.success(1), Future.success(2), Future.success(3)];
+
+        const values$ = Future.parallelWithAccumulation($futuresArray);
+        const expected: ParallelAccumulatedData<unknown, number> = {
+            type: "success",
+            data: [1, 2, 3],
+        };
+
+        await expectAsync(values$, { toEqual: expected });
+    });
+
+    it("if there is an error in any Future, it continues and returns an async containing all the other accumulated values as an array", async () => {
+        const $futuresArray = [Future.success(1), Future.error("error"), Future.success(3)];
+
+        const values$ = Future.parallelWithAccumulation($futuresArray);
+        const expected: ParallelAccumulatedData<string, number> = {
+            type: "error",
+            data: [1, 3],
+            errors: ["error"],
+        };
+
+        await expectAsync(values$, { toEqual: expected });
+    });
+
+    it("if an error occurs, it completes the current batch, accumulates all successful results from it, and terminates before starting the next batch", async () => {
+        const $futuresArray = [
+            Future.error("error"),
+            Future.success(2),
+            Future.success(3),
+            Future.success(4),
+        ];
+
+        const values$ = Future.parallelWithAccumulation($futuresArray, {
+            stopOnError: true,
+            concurrency: 2,
+        });
+        const expected: ParallelAccumulatedData<string, number> = {
+            type: "error",
+            data: [2],
+            errors: ["error"],
         };
 
         await expectAsync(values$, { toEqual: expected });

--- a/src/domain/entities/generic/__tests__/Future.spec.ts
+++ b/src/domain/entities/generic/__tests__/Future.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test, it, vi, expectTypeOf } from "vitest";
+import { Future } from "$/domain/entities/generic/Future";
 import {
-    Future,
     ParallelAccumulatedData,
     SequentialAccumulatedData,
-} from "$/domain/entities/generic/Future";
+} from "$/domain/entities/generic/FutureWithAccumulation";
 
 describe("Basic builders", () => {
     test("Future.success", async () => {


### PR DESCRIPTION
### :pushpin: References

### :memo: Implementation
- Add new Future method `parallelWithAccumulation`: accumulates successful results even on partial failures and stops before starting the next batch if stopOnError is active
- Add tests
- Fix Trivy installation  URL

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
