### PR TITLE
add dependency track github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
     master-workflow:
-      uses: EyeSeeTea/github-workflows/.github/workflows/master.yml@feature/add_bom_actions
+      uses: EyeSeeTea/github-workflows/.github/workflows/master.yml@master
       secrets:
         DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
     master-workflow:
       uses: EyeSeeTea/github-workflows/.github/workflows/master.yml@feature/add_bom_actions
       secrets:
-        DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
+        DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }} 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
     master-workflow:
       uses: EyeSeeTea/github-workflows/.github/workflows/master.yml@feature/add_bom_actions
       secrets:
-        DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }} 
+        DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,4 +9,6 @@ on:
 
 jobs:
     master-workflow:
-      uses: EyeSeeTea/github-workflows/.github/workflows/master.yml@master
+      uses: EyeSeeTea/github-workflows/.github/workflows/master.yml@feature/add_bom_actions
+      secrets:
+        DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}


### PR DESCRIPTION
📌 References
This PR enables repository access to the master branch and the secret, allowing the Dependency-Track dependency check to run.

Issue: Closes #?
https://app.clickup.com/t/4528615/869b6mend

📝 Implementation
Added the DTRACK_API_KEY secret to the shared workflow call so that the Dependency-Track jobs are no longer skipped. From now on, every push to master will generate a BOM and upload it to Dependency Track for vulnerability analysis.

📹 Screenshots/Screen capture
N/A

🔥 Testing
After merging, check the Actions tab to confirm the Dependency-Track jobs run successfully. Then open the Dependency-Track project link from the workflow summary to review the dependency analysis. If vulnerabilities are found, triage them there and resolve or suppress as appropriate.