### PR TITLE
fix: correct flatMap/chain type signatures in Future

### DIFF
--- a/src/domain/entities/generic/Future.ts
+++ b/src/domain/entities/generic/Future.ts
@@ -56,7 +56,7 @@ export class Future<E, D> {
         );
     }
 
-    flatMap<U, E>(fn: (data: D) => Future<U, E>): Future<U, E> {
+    flatMap<D2>(fn: (data: D) => Future<E, D2>): Future<E, D2> {
         return new Future(() => this._promise().then(data => fn(data)._promise()));
     }
 
@@ -68,7 +68,7 @@ export class Future<E, D> {
         });
     }
 
-    chain<U, E>(fn: (data: D) => Future<U, E>): Future<U, E> {
+    chain<D2>(fn: (data: D) => Future<E, D2>): Future<E, D2> {
         return this.flatMap(fn);
     }
 


### PR DESCRIPTION
## Summary

The `flatMap`/`chain` signatures declared their own type parameter `E`, shadowing the class error type, and placed it in the **data** slot of the returned `Future` (`Future<U, E>` = error `U`, data `E`), so the parameter names read backwards. This PR replaces both with the standard monadic bind signature, keeping the error type fixed:

```ts
flatMap<D2>(fn: (data: D) => Future<E, D2>): Future<E, D2>
```